### PR TITLE
Hotfix/comparefiles dlwcheck

### DIFF
--- a/comparefiles/comparefiles.ado
+++ b/comparefiles/comparefiles.ado
@@ -1,4 +1,6 @@
-*! version 1.0 18SEP2019 EduAnalytics eduanalytics@worldbank.org
+*! version 1.1 24MAY2026 EduAnalytics eduanalytics@worldbank.org
+* sval/lval render as N/A for missing string values in markdown report
+* version 1.0 18SEP2019 EduAnalytics eduanalytics@worldbank.org
 *! Author: Kristoffer Bjärkefur
 
 * This command is similar to cf, but this handles the case with difference
@@ -452,6 +454,13 @@ qui {
 								local lval = `compvar'__[`i']
 								local IDstr = `IDstring'[`i']
 								local diffstr = `diff'[`i']
+
+								if ("`sval'" == "" & "`diffstr'" == "N/A") {
+									local sval = "N/A"
+								}
+								if ("`lval'" == "" & "`diffstr'" == "N/A") {
+									local lval = "N/A"
+								}
 
 								markdown_missmatch_varval, filehandle(`filehandle') sval(`sval') lval(`lval') idstr("`IDstr'") diffstr(`diffstr')
 							}

--- a/src/ado_files/edukit_dlwcheck.ado
+++ b/src/ado_files/edukit_dlwcheck.ado
@@ -1,4 +1,6 @@
-*! version 1.0 18SEP2019 EduAnalytics eduanalytics@worldbank.org
+*! version 1.1 24MAY2026 EduAnalytics eduanalytics@worldbank.org
+* HLO_FOLDER_REPORT translate linesize 220 -> 255 (Stata max)
+* version 1.0 18SEP2019 EduAnalytics eduanalytics@worldbank.org
 
 cap program drop 	edukit_dlwcheck
 program define	edukit_dlwcheck, rclass
@@ -576,7 +578,7 @@ qui {
         *Copy the new master dofile from the tempfile to the original position
         copy "`tempfilename'"  `"`reportfolder'/test.smcl"' , replace
 
-        translate "`tempfilename'" `"`reportfolder'/HLO_FOLDER_REPORT_`timestamp'.txt"', trans(smcl2txt) replace linesize(220)
+        translate "`tempfilename'" `"`reportfolder'/HLO_FOLDER_REPORT_`timestamp'.txt"', trans(smcl2txt) replace linesize(255)
 
         noi di ""
         noi di `"{pstd}Report written to: {browse "`reportfolder'/HLO_FOLDER_REPORT_`timestamp'.txt":`reportfolder'/HLO_FOLDER_REPORT_`timestamp'.txt}{p_end}"'


### PR DESCRIPTION
## Summary

Two small hotfixes, originally proposed in #32 (open since 2022-03-23), reapplied cleanly without the whitespace/EOL-conversion noise that polluted that PR (1,135 line-touches for ~9 real changes).

- **`comparefiles.ado` (v1.0 -> v1.1)** — `mdreport()` rows for string variables with a missing value on one side rendered an empty markdown cell, breaking the table layout. The fix substitutes `N/A` in `sval`/`lval` when `diffstr == "N/A"` (set only for string vars) and the side itself is empty.
- **`edukit_dlwcheck.ado` (v1.0 -> v1.1)** — `HLO_FOLDER_REPORT` tables overflowed at `linesize(220)`. Bumped to 255 (Stata's legal max for `translate smcl2txt`). Output gets wider, never narrower.

Net diff: **+14 / -3** across 2 files. Two atomic commits, one per file.

## What this PR does NOT do

- Numeric-missing rendering in `comparefiles` markdown is unchanged. The wiggle-room branch already filters missing-vs-missing rows; missing-vs-nonmissing numeric rows render Stata's `.` literally, which is intentional. The version-header comment is narrowed accordingly.
- Pre-existing items visible in the diff but not addressed here:
  - `PLACEHOLDER compvar_str` strings for the `comparelocal`/`compareshared` branches.
  - `_rc` leakage potential in the `cap isid` dispatch blocks.

## Test plan

- [ ] Run `comparefiles` against two `.dta` files that differ on a string variable with a missing value on one side; confirm the markdown table renders `N/A` and the row layout is preserved.
- [ ] Run `comparefiles` against numeric-only differences; confirm prior behaviour (no regression).
- [ ] Run `edukit_dlwcheck` against a folder that previously overflowed at linesize 220; confirm the `HLO_FOLDER_REPORT_*.txt` is now wider and tables are no longer truncated.

Closes #32.
